### PR TITLE
Fix: couldn't resolve module error.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   swagger-watch:
     build: ./swagger-watch
     volumes:
-      - ./swagger-watch:/app
+      - ./swagger-watch/index.js:/app/index.js
       - ./src:/src
       - ./docs/swagger.yml:/docs/swagger.yml
     working_dir: /app

--- a/swagger-watch/Dockerfile
+++ b/swagger-watch/Dockerfile
@@ -3,5 +3,6 @@ FROM node:10-alpine
 WORKDIR /app
 
 COPY ./package.json /app/package.json
+COPY ./yarn.lock /app/yarn.lock
 RUN yarn install
 

--- a/swagger-watch/index.js
+++ b/swagger-watch/index.js
@@ -31,4 +31,5 @@ function watch() {
   gaze.on('added', (watcher) => restart());
   gaze.on('removed', (watcher) => restart());
 }
+multi_file();
 watch();


### PR DESCRIPTION
Hi, your product is awesome.

but, I can't run swagger-watch container. 
Becouse, couldn't resolve node modules like "gaze"

```
$ docker-compose build
$ docker-compose up -d
$ docker ps -a
CONTAINER ID        IMAGE                                     COMMAND                  CREATED             STATUS              PORTS                            NAMES
6f0dc9639b39        swagger-multi-file-docker_swagger-watch   "node index.js"          About an hour ago   Exited (137) 3 seconds ago                                     swagger-multi-file-docker_swagger-watch_1
// stopping swagger-multi-file-docker_swagger-watch container
```

The Reason of this Problem is  in docker-compose mount point.
The following code is override container project `node_module` dir. and delete all `node_module` packages

```
    volumes:
      - ./swagger-watch:/app
```

so, fix this this Problem. Could you confirm and this merge request  

thx